### PR TITLE
fix: lazy MCP client initialization

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2,6 +2,7 @@ import { openai } from "@ai-sdk/openai";
 import { frontendTools } from "@assistant-ui/react-ai-sdk";
 import {
   JSONSchema7,
+  ToolSet,
   streamText,
   convertToModelMessages,
   type UIMessage,
@@ -10,15 +11,28 @@ import { experimental_createMCPClient as createMCPClient } from "@ai-sdk/mcp";
 
 export const maxDuration = 30;
 
-const mcpClient = await createMCPClient({
-  // TODO adjust this to point to your MCP server URL
-  transport: {
-    type: "http",
-    url: "http://localhost:8000/mcp",
-  },
-});
+let mcpClient: Awaited<ReturnType<typeof createMCPClient>> | null = null;
+let cachedMCPTools: ToolSet | null = null;
 
-const mcpTools = await mcpClient.tools();
+async function getMCPTools(): Promise<ToolSet> {
+  if (cachedMCPTools) return cachedMCPTools;
+
+  try {
+    mcpClient = await createMCPClient({
+      // TODO adjust this to point to your MCP server URL
+      transport: {
+        type: "http",
+        url: "http://localhost:8000/mcp",
+      },
+    });
+    cachedMCPTools = await mcpClient.tools();
+    return cachedMCPTools;
+  } catch (e) {
+    console.warn("Failed to connect to MCP server:", e);
+    mcpClient = null;
+    return {};
+  }
+}
 
 export async function POST(req: Request) {
   const {
@@ -31,6 +45,8 @@ export async function POST(req: Request) {
     tools?: Record<string, { description?: string; parameters: JSONSchema7 }>;
   } =
     await req.json();
+
+  const mcpTools = await getMCPTools();
 
   const result = streamText({
     model: openai.responses("gpt-5-nano"),


### PR DESCRIPTION
## Summary
- Moves MCP client creation from top-level `await` (module-load time) to a lazy `getMCPTools()` function called per-request
- If the MCP server is unavailable, the chat endpoint continues working without MCP tools
- Failed attempts are not cached, so MCP tools activate automatically once the server comes online

## Test plan
- [x] `pnpm run build` succeeds with no MCP server running
- [x] Dev server starts without MCP server
- [x] Chat endpoint returns HTTP 200 and streams properly without MCP server
- [x] Only `route.ts` changed — no lockfile or config changes